### PR TITLE
Fix RC tagging workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           ref: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true


### PR DESCRIPTION
## Summary
- ensure tags are fetched during semantic-release job

## Testing
- `git status --short`