### PR TITLE
Fix RC tagging workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           ref: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true
+
+      - name: Ensure tags are fetched
+        run: git fetch --prune --force --tags
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- ensure tags are fetched for semantic-release

## Testing
- `git status --short`
